### PR TITLE
Increment template version.

### DIFF
--- a/src/logic-app-standard/devcontainer-template.json
+++ b/src/logic-app-standard/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "logic-app-standard",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "name": "Logic App Standard",
     "description": "A template for a Logic App Standard dev container.",
     "documentationUrl": "",


### PR DESCRIPTION
This pull request to `src/logic-app-standard/devcontainer-template.json` updates the version number of the dev container template from `0.0.4` to `0.0.5`.

Main change:

* <a href="diffhunk://#diff-c58b33cef5cb5b433b01d939150741c2718633839531b0bb11a7acdb69f6bb5fL3-R3">`src/logic-app-standard/devcontainer-template.json`</a>: Updated the version number of the `logic-app-standard` dev container template from `0.0.4` to `0.0.5`.