### PR TITLE
v1.0.0 release

### DIFF
--- a/src/logic-app-standard/devcontainer-template.json
+++ b/src/logic-app-standard/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "logic-app-standard",
-    "version": "0.0.6",
+    "version": "1.0.0",
     "name": "Logic App Standard",
     "description": "A template for a Logic App Standard dev container.",
     "documentationUrl": "",


### PR DESCRIPTION
This pull request updates the version of the logic app standard dev container template from "0.0.6" to "1.0.0" to indicate a major version milestone.

* <a href="diffhunk://#diff-c58b33cef5cb5b433b01d939150741c2718633839531b0bb11a7acdb69f6bb5fL3-R3">`src/logic-app-standard/devcontainer-template.json`</a>: Updated the logic app standard dev container template version from "0.0.6" to "1.0.0" to indicate a major version milestone.