### PR TITLE
Fix postCreateCommand failing to execute script.

### DIFF
--- a/src/logic-app-standard/.devcontainer/devcontainer.json
+++ b/src/logic-app-standard/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     // The local.settings.json file is needed for the workflow designer (as part of the Azure Functions runtime). The local.settings.json file
     // is normally ignored via the .gitignore file created in a new Logic App Standard (or Azure Functions) project.
-    "postCreateCommand": "echo '${templateOption:imageVariant}' > /tmp/logic-app-standard.txt && sudo .devcontainer/scripts/setup-local-settings.sh",
+    "postCreateCommand": "echo '${templateOption:imageVariant}' > /tmp/logic-app-standard.txt && bash .devcontainer/scripts/setup-local-settings.sh",
     // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/src/logic-app-standard/.devcontainer/scripts/setup-local-settings.sh
+++ b/src/logic-app-standard/.devcontainer/scripts/setup-local-settings.sh
@@ -26,6 +26,3 @@ else
     cp $HOST_TEMPLATE_SETTINGS $HOST_LOCAL_SETTINGS
     echo "Copied local template settings."
 fi
-
-
-# chown vscode .azure-functions-core-tools

--- a/src/logic-app-standard/.devcontainer/scripts/setup-local-settings.sh
+++ b/src/logic-app-standard/.devcontainer/scripts/setup-local-settings.sh
@@ -28,4 +28,4 @@ else
 fi
 
 
-chown vscode .azure-functions-core-tools
+# chown vscode .azure-functions-core-tools

--- a/src/logic-app-standard/devcontainer-template.json
+++ b/src/logic-app-standard/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "logic-app-standard",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Logic App Standard",
     "description": "A template for a Logic App Standard dev container.",
     "documentationUrl": "",


### PR DESCRIPTION
This pull request includes changes related to the development environment setup for the logic app standard project. The most important changes include updating the `postCreateCommand` in `devcontainer.json` to use `bash` instead of `sudo`, removing a line that changes ownership of a directory in the `setup-local-settings.sh` script, and updating the version number in the `devcontainer-template.json` file.

Version update:

* <a href="diffhunk://#diff-c58b33cef5cb5b433b01d939150741c2718633839531b0bb11a7acdb69f6bb5fL3-R3">`src/logic-app-standard/devcontainer-template.json`</a>: Updated the version number in the `devcontainer-template.json` file from `1.0.0` to `1.0.1`.This pull request includes updates to the Logic App Standard template and its devcontainer configuration. The most important changes include updating the version number of the template and changing the execution privileges of a script in the devcontainer configuration.

Main template and configuration changes:

* <a href="diffhunk://#diff-c58b33cef5cb5b433b01d939150741c2718633839531b0bb11a7acdb69f6bb5fL3-R3">`src/logic-app-standard/devcontainer-template.json`</a>: Updated the version number of the Logic App Standard template.
* <a href="diffhunk://#diff-17cb805eeb11c6dfe6dbcb880bcbd42d932666e5ee8935a12ab8c3484b921484L40-R40">`src/logic-app-standard/.devcontainer/devcontainer.json`</a>: Updated the `postCreateCommand` property to use `bash` instead of `sudo` for running the `setup-local-settings.sh` script.
* <a href="diffhunk://#diff-ad1913ba2a9f09f0c56f89c7300534f503384dee8e1b12230dc4022acbfbcc6cL29-L31">`src/logic-app-standard/.devcontainer/scripts/setup-local-settings.sh`</a>: Removed the line that changes ownership of the `.azure-functions-core-tools` directory to the `vscode` user in the `setup-local-settings.sh` script.
